### PR TITLE
GetModelVersion api path is versions/{id} not version/{id}

### DIFF
--- a/src/Replicate.Net/Client/IReplicateApi.cs
+++ b/src/Replicate.Net/Client/IReplicateApi.cs
@@ -47,7 +47,7 @@ public interface IReplicateApi
     [Get("models/{owner}/{name}/versions")]
     Task<PagedResult<ModelVersion>> GetModelVersionsAsync([Path] string owner, [Path] string name, CancellationToken cancellationToken = default);
 
-    [Get("models/{owner}/{name}/version/{id}")]
+    [Get("models/{owner}/{name}/versions/{id}")]
     Task<PagedResult<ModelVersion>> GetModelVersionAsync([Path] string owner, [Path] string name, [Path] string id, CancellationToken cancellationToken = default);
 
     [Get("{url}")]


### PR DESCRIPTION
https://replicate.com/docs/reference/http#models.versions.get